### PR TITLE
feat: add a method to set the body of the request during index creation

### DIFF
--- a/collective/elasticsearch/interfaces.py
+++ b/collective/elasticsearch/interfaces.py
@@ -11,6 +11,9 @@ class IElasticSearchCatalog(Interface):
 
 
 class IMappingProvider(Interface):
+    def get_index_creation_body():
+        pass
+
     def __call__():
         pass
 

--- a/collective/elasticsearch/mapping.py
+++ b/collective/elasticsearch/mapping.py
@@ -17,6 +17,9 @@ class MappingAdapter(object):
         self.es = es
         self.catalog = es.catalog
 
+    def get_index_creation_body(self):
+        return {}
+
     def __call__(self):
         properties = self._default_mapping.copy()
         for name in self.catalog.indexes.keys():
@@ -39,7 +42,7 @@ class MappingAdapter(object):
                 self.es.bump_index_version()
             index_name_v = '%s_%i' % (index_name, self.es.index_version)
             if not conn.indices.exists(index_name_v):
-                conn.indices.create(index_name_v)
+                conn.indices.create(index_name_v, body=self.get_index_creation_body())
             if not conn.indices.exists_alias(name=index_name):
                 conn.indices.put_alias(index=index_name_v, name=index_name)
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -54,6 +54,23 @@ the _default_mapping attribute to add your own indexes::
         }
 
 
+Changing the settings of the index
+----------------------------------
+
+If you want to customize your elasticsearch index, you can override the ``get_index_creation_body`` method on the ``MappingAdapter``::
+
+    class MyMappingAdapter(object):
+        implements(IMappingProvider)
+
+        def get_index_creation_body(self):
+            return {
+                "settings" : {
+                    "number_of_shards": 1,
+                    "number_of_replicas": 0
+                }
+            }
+
+
 Changing the query made to elasticsearch
 ----------------------------------------
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,9 @@ Changelog
 2.0.0a3 (Unreleased)
 --------------------
 
+- Add a method to set the body of the request during index creation.
+  [Gagaro]
+
 - Fixed get brain in lazy list with negative indexes.
   [thomasdesvenain]
 


### PR DESCRIPTION
I saw the other PR and this seems like the best way to have a way of changing the settings and be the more versatile possible.

What do you think about that?