### PR TITLE
converting to Zope DateTime

### DIFF
--- a/collective/elasticsearch/indexes.py
+++ b/collective/elasticsearch/indexes.py
@@ -49,7 +49,7 @@ def _zdt(val):
 keyword_fields = (
     "allowedRolesAndUsers", "portal_type", "object_provides", "Type",
     "id", "cmf_uid", "sync_uid", "getId", "meta_type", "review_state",
-    "in_reply_to", "UID", "getRawRelatedItems", "Subject")
+    "in_reply_to", "UID", "getRawRelatedItems", "Subject", "sortable_title")
 
 
 class BaseIndex(object):

--- a/collective/elasticsearch/indexes.py
+++ b/collective/elasticsearch/indexes.py
@@ -3,7 +3,7 @@ from Acquisition import aq_base
 from Acquisition import aq_parent
 from collective.elasticsearch import logger
 from DateTime import DateTime
-from datetime import datetime
+from datetime import datetime, date
 from Missing import MV
 from Products.ExtendedPathIndex.ExtendedPathIndex import ExtendedPathIndex
 from Products.PluginIndexes.BooleanIndex.BooleanIndex import BooleanIndex
@@ -41,6 +41,8 @@ def _one(val):
 def _zdt(val):
     if type(val) == datetime:
         val = DateTime(val)
+    elif type(val) == date:
+        val = DateTime(datetime.fromordinal(val.toordinal()))
     elif isinstance(val, text_type):
         val = DateTime(val)
     return val

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,10 +1,17 @@
 Changelog
 =========
 
-3.0.1 (unreleased)
+3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix Zope DateTime convert to also handle the datetime.date type [ewohnlich]
+
+
+3.0.1 (2019-01-28)
+------------------
+
+- Fix sortable_title search issue
+  [ewohnlich]
 
 
 3.0.0 (2019-01-28)


### PR DESCRIPTION
The _zdt function already converted datetime.datetime objects to Zope DateTime. However the datetime.date type was not handled, which this request aims to address. (I suspect it is much less common for people to store datetime.date in their ZCatalogs but as far as I can tell there is nothing that forbids it).