### PR TITLE
Fix contentrule/commit hook reindexing issue

### DIFF
--- a/collective/elasticsearch/hook.py
+++ b/collective/elasticsearch/hook.py
@@ -57,11 +57,12 @@ def index_batch(remove, index, positions, es=None):
 
         for uid, obj in index.items():
             # If content has been moved (ie by a contentrule) then the object
-            # passed here is the original object, not the moved one. By getting
-            # the object from the uuid, we avoid the issues this causes...
+            # passed here is the original object, not the moved one.
+            # So if there is a uuid, we use this to get the correct object.
             # See https://github.com/collective/collective.elasticsearch/issues/65 # noqa
             if uid is not None:
                 obj = uuidToObject(uid)
+
             if obj is None:
                 obj = uuidToObject(uid)
                 if obj is None:

--- a/collective/elasticsearch/hook.py
+++ b/collective/elasticsearch/hook.py
@@ -56,6 +56,12 @@ def index_batch(remove, index, positions, es=None):
         bulk_data = []
 
         for uid, obj in index.items():
+            # If content has been moved (ie by a contentrule) then the object
+            # passed here is the original object, not the moved one. By getting
+            # the object from the uuid, we avoid the issues this causes...
+            # See https://github.com/collective/collective.elasticsearch/issues/65 # noqa
+            if uid is not None:
+                obj = uuidToObject(uid)
             if obj is None:
                 obj = uuidToObject(uid)
                 if obj is None:

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,7 +4,8 @@ Changelog
 2.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix commit hook bug when content has been moved
+  [instification]
 
 
 2.0.5 (2018-12-20)


### PR DESCRIPTION
use uuidToObject instead of trusting passed in object

workaround for #65 