### PR TITLE
Fix commit hook bug when content has been moved

### DIFF
--- a/collective/elasticsearch/hook.py
+++ b/collective/elasticsearch/hook.py
@@ -57,6 +57,13 @@ def index_batch(remove, index, positions, es=None):
         bulk_data = []
 
         for uid, obj in index.items():
+            # If content has been moved (ie by a contentrule) then the object
+            # passed here is the original object, not the moved one.
+            # So if there is a uuid, we use this to get the correct object.
+            # See https://github.com/collective/collective.elasticsearch/issues/65 # noqa
+            if uid is not None:
+                obj = uuidToObject(uid)
+
             if obj is None:
                 obj = uuidToObject(uid)
                 if obj is None:

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,7 +4,8 @@ Changelog
 3.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix commit hook bug when content has been moved
+  [instification]
 
 
 3.0.4 (2019-08-21)


### PR DESCRIPTION
Cherry pick of #66  from 2.0.x branch.

Closes #65 