### PR TITLE
Explicit error logging added, if ES bulk action for indexing failed 

### DIFF
--- a/collective/elasticsearch/hook.py
+++ b/collective/elasticsearch/hook.py
@@ -45,10 +45,13 @@ def index_batch(remove, index, positions, es=None):
                     '_id': uid
                 }
             })
-        es.connection.bulk(
+        result = es.connection.bulk(
             index=es.index_name,
             doc_type=es.doc_type,
             body=bulk_data)
+
+        if "errors" in result and result["errors"] is True:
+            logger.error("Error in bulk indexing removal: %s" % result)
 
     if len(index) > 0:
         if type(index) in (list, tuple, set):
@@ -76,17 +79,24 @@ def index_batch(remove, index, positions, es=None):
                 }
             }, get_index_data(obj, es)])
             if len(bulk_data) % bulk_size == 0:
-                conn.bulk(
+                result = conn.bulk(
                     index=es.index_name,
                     doc_type=es.doc_type,
                     body=bulk_data)
+
+                if "errors" in result and result["errors"] is True:
+                    logger.error("Error in bulk indexing: %s" % result)
+
                 bulk_data = []
 
         if len(bulk_data) > 0:
-            conn.bulk(
+            result = conn.bulk(
                 index=es.index_name,
                 doc_type=es.doc_type,
                 body=bulk_data)
+
+            if "errors" in result and result["errors"] is True:
+                logger.error("Error in bulk indexing: %s" % result)
 
     if len(positions) > 0:
         bulk_data = []

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,9 @@ Changelog
 - Fix commit hook bug when content has been moved
   [instification]
 
+- Explicit error logging added, if ES bulk action for indexing failed.
+  [nazrulworld]
+
 
 3.0.4 (2019-08-21)
 ------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,11 +4,11 @@ Changelog
 3.0.5 (unreleased)
 ------------------
 
-- Fix commit hook bug when content has been moved
-  [instification]
-
 - Explicit error logging added, if ES bulk action for indexing failed.
   [nazrulworld]
+
+- Fix commit hook bug when content has been moved
+  [instification]
 
 
 3.0.4 (2019-08-21)


### PR DESCRIPTION
I had a situation, where we see one type of object's index missing because of some problem with mapping and object's field value (complex JSON structured) but was completely silent!

We tried a lot, to debug but no error log found. After then I added these changes, now we can understand what was our exact problem.
