### PR TITLE
Unify tests extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,12 +60,6 @@ setup(
             'plone.app.contenttypes',
             'plone.app.testing',
             'plone.testing>=5.0.0',
-            'unittest2',
-        ],
-        'test-archetypes': [
-            'plone.app.contentrules',
-            'plone.app.testing',
-            'plone.testing>=5.0.0',
             'Products.ATContentTypes',
             'unittest2',
         ],

--- a/test_plone50.cfg
+++ b/test_plone50.cfg
@@ -5,8 +5,6 @@ extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
     base.cfg
 
-package-extras = [test-archetypes]
-
 [versions]
 elasticsearch = 7.6.0
 backports.ssl-match-hostname = 3.5.0.1

--- a/test_plone51.cfg
+++ b/test_plone51.cfg
@@ -5,8 +5,6 @@ extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
     base.cfg
 
-package-extras = [test-archetypes]
-
 [versions]
 elasticsearch = 7.6.0
 plone.testing = 5.0.0


### PR DESCRIPTION
It makes no sense to have two if only one is used in tests.