### PR TITLE
Update elasticsearch to 7.17.7 + minor optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## 5.0.1 (unreleased)
 
-- Nothing changed yet.
+- Update elasticsearch to 7.17.7 (Ready for 8.x and apple silicon images are available) @maethu
+
+- Control-Panel: Fix potential issue with bool fields @maethu
+
+- Tests: Wait for elasticsearch service @maethu
 
 
 ## 5.0.0 (2022-10-11)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ YELLOW=`tput setaf 3`
 PLONE5=5.2-latest
 PLONE6=6.0-latest
 
-ELASTIC_SEARCH_IMAGE=elasticsearch:7.7.0
+ELASTIC_SEARCH_IMAGE=elasticsearch:7.17.7
 ELASTIC_SEARCH_CONTAINER=elastictest
 
 CONTAINERS=$$(docker ps -q -a -f "name=${ELASTIC_SEARCH_CONTAINER}" | wc -l)

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "setuptools",
-        "elasticsearch==7.7.0",
+        "elasticsearch==7.17.7",
         "plone.app.registry",
         "plone.api",
         "setuptools",

--- a/src/collective/elasticsearch/interfaces.py
+++ b/src/collective/elasticsearch/interfaces.py
@@ -42,7 +42,7 @@ class IQueryAssembler(Interface):
 
 class IElasticSettings(Interface):
 
-    enabled = schema.Bool(title="Enabled", default=False)
+    enabled = schema.Bool(title="Enabled", default=False, required=False)
 
     hosts = schema.List(
         title="Hosts",
@@ -57,17 +57,19 @@ class IElasticSettings(Interface):
         value_type=schema.TextLine(title="Index"),
     )
 
-    sniff_on_start = schema.Bool(title="Sniff on start", default=False)
+    sniff_on_start = schema.Bool(title="Sniff on start", default=False, required=False)
 
     sniff_on_connection_fail = schema.Bool(
-        title="Sniff on connection fail", default=False
+        title="Sniff on connection fail", default=False, required=False
     )
 
     sniffer_timeout = schema.Float(
         title="Sniffer timeout", required=False, default=None
     )
 
-    retry_on_timeout = schema.Bool(title="Retry on timeout", default=True)
+    retry_on_timeout = schema.Bool(
+        title="Retry on timeout", default=True, required=False
+    )
 
     timeout = schema.Float(
         title="Read timeout",


### PR DESCRIPTION
- This makes elasticsearch ready for a upgrade to 8.x (https://www.elastic.co/guide/en/elastic-stack/8.4/upgrading-elastic-stack.html#prepare-to-upgrade)
- There are apple silicon images available - 7.7.0 image did not work as amd64 image on arm64

Tests:
- At least for me sometimes plone was faster than pulling a new elasticsearch
image.

Control-Panel:
- Fix a potential issue with z3c.forms. Depending on the z3c.form version without the "required "flag the bool fields are marked mandatory and cannot be changed. 

Info regarding upgrading elasticsearch from 7.7.0 to 7.17.7 -> https://www.elastic.co/guide/en/elasticsearch/reference/7.17/setup-upgrade.html
