### PR TITLE
Implement search highlighting feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Tests: Wait for elasticsearch service @maethu
 
+- Add support for highlight feature of elasticsearch @instification
 
 ## 5.0.0 (2022-10-11)
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,4 @@
 - Wesley Barroso, wesleybl@gmail.com
 - André Climaco, andre.climaco@gmail.com
 - Érico Andrei, ericof@plone.org
+- Jon Pentland, jon.pentland@pretagov.co.uk

--- a/README.md
+++ b/README.md
@@ -215,6 +215,20 @@ This feature aims to have a minimal impact in terms of responsiveness of the plo
 Support for all index column types is done EXCEPT for the DateRecurringIndex index column type. If you are doing a full text search along with a query that contains a DateRecurringIndex column, it will not work.
 
 
+## Search Highlighting
+
+If you want to make use of the [Elasticsearch highlight](https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html) feature you can enable it in the control panel.
+
+When enabled, it will replace the description of search results with the highlighted fragments from elastic search.
+
+### Highlight Threshold
+
+This is the number of characters to show in the description. Fragments will be added until this threshold is met.
+
+### Pre/Post Tags
+
+Highlighted terms can be wrapped in html which can be used to enhance the results further, such as by adding a custom background color. Note that the default Plone search results will not render html so to use this feature you will need to create a custom saearch result view.
+
 ## Developing this package
 
 Create the virtual enviroment and install all dependencies:

--- a/src/collective/elasticsearch/interfaces.py
+++ b/src/collective/elasticsearch/interfaces.py
@@ -121,8 +121,6 @@ class IElasticSettings(Interface):
     )
 
 
-
-
 class IElasticSearchIndexQueueProcessor(IIndexQueueProcessor):
     """Index queue processor for elasticsearch."""
 

--- a/src/collective/elasticsearch/interfaces.py
+++ b/src/collective/elasticsearch/interfaces.py
@@ -92,6 +92,36 @@ class IElasticSettings(Interface):
         title="Bulk Size", description="bulk size for elastic queries", default=50
     )
 
+    highlight = schema.Bool(
+        title="Enable Search Highlight",
+        description="Use elasticsearch highlight feature instead of descriptions in search results",
+        default=False,
+        required=False
+    )
+
+    highlight_threshold = schema.Int(
+        title="Highlight Threshold",
+        description="Number of highlighted characters to display in search results descriptions",
+        default=600,
+        required=False
+    )
+
+    highlight_pre_tags = schema.Text(
+        title="Highlight pre tags",
+        description="Used with highlight post tags to wrap matching words. e.g. &lt;pre class=\"highlight\"&gt;. One tag per line",
+        default="",
+        required=False
+    )
+
+    highlight_post_tags = schema.Text(
+        title="Higlight post tags",
+        description="Used with highlight pre tags to wrap matching words. e.g. &lt;/pre&gt; One tag per line",
+        default="",
+        required=False
+    )
+
+
+
 
 class IElasticSearchIndexQueueProcessor(IIndexQueueProcessor):
     """Index queue processor for elasticsearch."""

--- a/src/collective/elasticsearch/interfaces.py
+++ b/src/collective/elasticsearch/interfaces.py
@@ -96,28 +96,28 @@ class IElasticSettings(Interface):
         title="Enable Search Highlight",
         description="Use elasticsearch highlight feature instead of descriptions in search results",
         default=False,
-        required=False
+        required=False,
     )
 
     highlight_threshold = schema.Int(
         title="Highlight Threshold",
         description="Number of highlighted characters to display in search results descriptions",
         default=600,
-        required=False
+        required=False,
     )
 
     highlight_pre_tags = schema.Text(
         title="Highlight pre tags",
-        description="Used with highlight post tags to wrap matching words. e.g. &lt;pre class=\"highlight\"&gt;. One tag per line",
+        description='Used with highlight post tags to wrap matching words. e.g. &lt;pre class="highlight"&gt;. One tag per line',
         default="",
-        required=False
+        required=False,
     )
 
     highlight_post_tags = schema.Text(
         title="Higlight post tags",
         description="Used with highlight pre tags to wrap matching words. e.g. &lt;/pre&gt; One tag per line",
         default="",
-        required=False
+        required=False,
     )
 
 

--- a/src/collective/elasticsearch/manager.py
+++ b/src/collective/elasticsearch/manager.py
@@ -46,7 +46,7 @@ class ElasticSearchManager:
 
     @property
     def highlight(self):
-        """ Is search highlighting enabled in the control panel."""
+        """Is search highlighting enabled in the control panel."""
         try:
             value = api.portal.get_registry_record(
                 "highlight", interfaces.IElasticSettings, False
@@ -57,7 +57,7 @@ class ElasticSearchManager:
 
     @property
     def highlight_threshold(self):
-        """ Is search highlighting enabled in the control panel."""
+        """Search highlighting threshold."""
         try:
             value = api.portal.get_registry_record(
                 "highlight_threshold", interfaces.IElasticSettings, False
@@ -68,7 +68,7 @@ class ElasticSearchManager:
 
     @property
     def highlight_pre_tags(self):
-        """ Is search highlighting enabled in the control panel."""
+        """Search highlighting pre tags."""
         try:
             value = api.portal.get_registry_record(
                 "highlight_pre_tags", interfaces.IElasticSettings, ""
@@ -81,7 +81,7 @@ class ElasticSearchManager:
 
     @property
     def highlight_post_tags(self):
-        """ Is search highlighting enabled in the control panel."""
+        """Search highlighting post tags."""
         try:
             value = api.portal.get_registry_record(
                 "highlight_post_tags", interfaces.IElasticSettings, ""
@@ -353,8 +353,9 @@ class ElasticSearchManager:
         if self.highlight:
             body["highlight"] = {
                 "fields": {"SearchableText": {"number_of_fragments": 5}},
-                "pre_tags": self.highlight_pre_tags.split('\n'),
-                "post_tags": self.highlight_post_tags.split('\n')}
+                "pre_tags": self.highlight_pre_tags.split("\n"),
+                "post_tags": self.highlight_post_tags.split("\n"),
+            }
         return self.connection.search(index=self.index_name, body=body, **query_params)
 
     def search(self, query: dict, factory=None, **query_params) -> LazyMap:

--- a/src/collective/elasticsearch/manager.py
+++ b/src/collective/elasticsearch/manager.py
@@ -45,6 +45,54 @@ class ElasticSearchManager:
         return value
 
     @property
+    def highlight(self):
+        """ Is search highlighting enabled in the control panel."""
+        try:
+            value = api.portal.get_registry_record(
+                "highlight", interfaces.IElasticSettings, False
+            )
+        except KeyError:
+            value = False
+        return value
+
+    @property
+    def highlight_threshold(self):
+        """ Is search highlighting enabled in the control panel."""
+        try:
+            value = api.portal.get_registry_record(
+                "highlight_threshold", interfaces.IElasticSettings, False
+            )
+        except KeyError:
+            value = 600
+        return value
+
+    @property
+    def highlight_pre_tags(self):
+        """ Is search highlighting enabled in the control panel."""
+        try:
+            value = api.portal.get_registry_record(
+                "highlight_pre_tags", interfaces.IElasticSettings, ""
+            )
+        except KeyError:
+            value = ""
+        if value is None:
+            value = ""
+        return value
+
+    @property
+    def highlight_post_tags(self):
+        """ Is search highlighting enabled in the control panel."""
+        try:
+            value = api.portal.get_registry_record(
+                "highlight_post_tags", interfaces.IElasticSettings, ""
+            )
+        except KeyError:
+            value = ""
+        if value is None:
+            value = ""
+        return value
+
+    @property
     def catalog(self):
         return api.portal.get_tool("portal_catalog")
 
@@ -302,6 +350,11 @@ class ElasticSearchManager:
         if sort is not None:
             body["sort"] = sort
         warnings.simplefilter("ignore", ResourceWarning)
+        if self.highlight:
+            body["highlight"] = {
+                "fields": {"SearchableText": {"number_of_fragments": 5}},
+                "pre_tags": self.highlight_pre_tags.split('\n'),
+                "post_tags": self.highlight_post_tags.split('\n')}
         return self.connection.search(index=self.index_name, body=body, **query_params)
 
     def search(self, query: dict, factory=None, **query_params) -> LazyMap:

--- a/src/collective/elasticsearch/profiles.zcml
+++ b/src/collective/elasticsearch/profiles.zcml
@@ -65,4 +65,18 @@
 
   </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeSteps
+      profile="collective.elasticsearch:default"
+      source="3"
+      destination="4"
+      >
+
+    <genericsetup:upgradeStep
+        title="Update registry."
+        description=""
+        handler=".upgrades.update_registry"
+        />
+
+  </genericsetup:upgradeSteps>
+
 </configure>

--- a/src/collective/elasticsearch/profiles/default/metadata.xml
+++ b/src/collective/elasticsearch/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>3</version>
+  <version>4</version>
   <dependencies>
 </dependencies>
 </metadata>

--- a/src/collective/elasticsearch/result.py
+++ b/src/collective/elasticsearch/result.py
@@ -84,7 +84,7 @@ def BrainFactory(manager):
                     if idx > 0 and fraglen > manager.highlight_threshold:
                         break
                     fragments.append(i)
-                brain["Description"] = ' ... '.join(fragments)
+                brain["Description"] = " ... ".join(fragments)
             return brain
         # We should handle cases where there is no path in the ES response
         return None

--- a/src/collective/elasticsearch/result.py
+++ b/src/collective/elasticsearch/result.py
@@ -76,6 +76,15 @@ def BrainFactory(manager):
             if not brain:
                 result = manager.get_record_by_path(path)
                 brain = ElasticSearchBrain(record=result, catalog=catalog)
+            if manager.highlight:
+                fragments = []
+                fraglen = 0
+                for idx, i in enumerate(result["highlight"]["SearchableText"]):
+                    fraglen += len(i)
+                    if idx > 0 and fraglen > manager.highlight_threshold:
+                        break
+                    fragments.append(i)
+                brain["Description"] = ' ... '.join(fragments)
             return brain
         # We should handle cases where there is no path in the ES response
         return None

--- a/src/collective/elasticsearch/tests/test_search.py
+++ b/src/collective/elasticsearch/tests/test_search.py
@@ -1,7 +1,7 @@
 from collective.elasticsearch.testing import ElasticSearch_FUNCTIONAL_TESTING
 from collective.elasticsearch.testing import ElasticSearch_REDIS_TESTING
 from collective.elasticsearch.tests import BaseFunctionalTest
-from collective.elasticsearch.utils import getESOnlyIndexes
+from collective.elasticsearch.utils import getESOnlyIndexes, get_settings
 from DateTime import DateTime
 from parameterized import parameterized
 from parameterized import parameterized_class
@@ -168,6 +168,21 @@ class TestSearch(BaseFunctionalTest):
             "SearchableText": "folder",
         }
         self.assertEqual(self.total_results(query), 1)
+
+    def test_highlight_query(self):
+        settings = get_settings()
+        settings.highlight = True
+        settings.highlight_pre_tags = '<em>'
+        settings.highlight_post_tags = '</em>'
+        api.content.create(self.portal,
+                           "Document",
+                           "page",
+                           title="Some Page")
+        self.commit(wait=1)
+        query = {'SearchableText': 'some'}
+        results = self.search(query)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].Description, "page <em>Some</em> Page")
 
 
 @parameterized_class(

--- a/src/collective/elasticsearch/tests/test_search.py
+++ b/src/collective/elasticsearch/tests/test_search.py
@@ -173,14 +173,11 @@ class TestSearch(BaseFunctionalTest):
     def test_highlight_query(self):
         settings = get_settings()
         settings.highlight = True
-        settings.highlight_pre_tags = '<em>'
-        settings.highlight_post_tags = '</em>'
-        api.content.create(self.portal,
-                           "Document",
-                           "page",
-                           title="Some Page")
+        settings.highlight_pre_tags = "<em>"
+        settings.highlight_post_tags = "</em>"
+        api.content.create(self.portal, "Document", "page", title="Some Page")
         self.commit(wait=1)
-        query = {'SearchableText': 'some'}
+        query = {"SearchableText": "some"}
         results = self.search(query)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].Description, "page <em>Some</em> Page")

--- a/src/collective/elasticsearch/tests/test_search.py
+++ b/src/collective/elasticsearch/tests/test_search.py
@@ -1,7 +1,8 @@
 from collective.elasticsearch.testing import ElasticSearch_FUNCTIONAL_TESTING
 from collective.elasticsearch.testing import ElasticSearch_REDIS_TESTING
 from collective.elasticsearch.tests import BaseFunctionalTest
-from collective.elasticsearch.utils import getESOnlyIndexes, get_settings
+from collective.elasticsearch.utils import get_settings
+from collective.elasticsearch.utils import getESOnlyIndexes
 from DateTime import DateTime
 from parameterized import parameterized
 from parameterized import parameterized_class


### PR DESCRIPTION
This PR adds the highlight feature of elasticsearch to enhance search results.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html for details of the feature.

The feature is added in a non breaking way, ie it is disabled by default and must be enabled in the settings to take effect.

When enabled, it will replace the Description of a brain with the matching fragments from the highlighted search. It does this on the fly, ie it makes no changes to the object.

Also includes a test and description in the readme.