### PR TITLE
Handle negative term filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Add support for highlight feature of elasticsearch @instification
 
+- Handle negative term filters (fixes #101) @instification
+
 ## 5.0.0 (2022-10-11)
 
 - Rename `master` branch to `main` @ericof

--- a/src/collective/elasticsearch/indexes.py
+++ b/src/collective/elasticsearch/indexes.py
@@ -99,6 +99,12 @@ class BaseIndex:
             if len(value) == 0:
                 return None
             return {"terms": {name: value}}
+        if isinstance(value, dict) and "not" in value:
+            if isinstance(value["not"], (list, tuple, set)):
+                return {
+                    "bool": {"must_not": [{"term": {name: i}} for i in value["not"]]}
+                }
+            return {"bool": {"must_not": [{"term": {name: value["not"]}}]}}
         return {"term": {name: value}}
 
 

--- a/src/collective/elasticsearch/interfaces.py
+++ b/src/collective/elasticsearch/interfaces.py
@@ -120,6 +120,13 @@ class IElasticSettings(Interface):
         required=False,
     )
 
+    raise_search_exception = schema.Bool(
+        title="Raise Search Exceptions",
+        description="If there is an error with elastic search Plone will default to trying the old catalog search. Set this to true to raise the error instead.",
+        default=False,
+        required=False
+    )
+
 
 class IElasticSearchIndexQueueProcessor(IIndexQueueProcessor):
     """Index queue processor for elasticsearch."""

--- a/src/collective/elasticsearch/interfaces.py
+++ b/src/collective/elasticsearch/interfaces.py
@@ -124,7 +124,7 @@ class IElasticSettings(Interface):
         title="Raise Search Exceptions",
         description="If there is an error with elastic search Plone will default to trying the old catalog search. Set this to true to raise the error instead.",
         default=False,
-        required=False
+        required=False,
     )
 
 

--- a/src/collective/elasticsearch/tests/__init__.py
+++ b/src/collective/elasticsearch/tests/__init__.py
@@ -40,6 +40,9 @@ class BaseTest(unittest.TestCase):
         settings.enabled = True
         settings.sniffer_timeout = 0.0
 
+        # Raise elastic search exceptions
+        settings.raise_search_exception = True
+
         self._wait_for_es_service()
 
         self.catalog = api.portal.get_tool("portal_catalog")

--- a/src/collective/elasticsearch/tests/test_search.py
+++ b/src/collective/elasticsearch/tests/test_search.py
@@ -188,9 +188,10 @@ class TestSearch(BaseFunctionalTest):
         self.commit(wait=1)
         query = {
             "portal_type": {"not": ["Event", "News Item"]},
-            "SearchableText": "New"
+            "SearchableText": "New",
         }
         self.assertEqual(self.total_results(query), 1)
+
 
 @parameterized_class(
     [

--- a/src/collective/elasticsearch/tests/test_search.py
+++ b/src/collective/elasticsearch/tests/test_search.py
@@ -182,6 +182,15 @@ class TestSearch(BaseFunctionalTest):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].Description, "page <em>Some</em> Page")
 
+    def test_not_query(self):
+        api.content.create(self.portal, "Document", "page", title="New Content")
+        api.content.create(self.portal, "Event", "event", title="New Event")
+        self.commit(wait=1)
+        query = {
+            "portal_type": {"not": ["Event", "News Item"]},
+            "SearchableText": "New"
+        }
+        self.assertEqual(self.total_results(query), 1)
 
 @parameterized_class(
     [


### PR DESCRIPTION
Fixes #101 

PR to construct queries for elasticsearch where there is a 'not' filter being passed in.

I am also adding a registry option to raise elasticsearch exceptions and doing so in the tests. Currently, exceptions are swallowed and the old catalog search is tried. This causes errors to be masked in the tests that would otherwise be caught.

As #100 is unreleased I don't think there is any need for an upgrade step with this PR.