### PR TITLE
Make search highlighting code defensive when adding to results

### DIFF
--- a/src/collective/elasticsearch/result.py
+++ b/src/collective/elasticsearch/result.py
@@ -76,10 +76,10 @@ def BrainFactory(manager):
             if not brain:
                 result = manager.get_record_by_path(path)
                 brain = ElasticSearchBrain(record=result, catalog=catalog)
-            if manager.highlight:
+            if manager.highlight and result.get("highlight"):
                 fragments = []
                 fraglen = 0
-                for idx, i in enumerate(result["highlight"]["SearchableText"]):
+                for idx, i in enumerate(result["highlight"].get("SearchableText", [])):
                     fraglen += len(i)
                     if idx > 0 and fraglen > manager.highlight_threshold:
                         break


### PR DESCRIPTION
The previous pr #100 added search highlighting by updating the brains on the fly. Issue #101 details a scenario where elastic can throw an exception.

In situations where there is an exception with elastic, the old search query is run, but the results don't contain the necessary `highlight` key. This would cause an exception.

This PR adds some defensiveness so that if the elastic search fails it won't attempt to modify the search results.

Not including any changelog because it is already covered by the unreleased #100.

I tried to write a test to expose the problem but it's not trivial to induce an exception in elastic in the tests (at least not after #102 is merged)