### PR TITLE
Use _old_searchResults when patching safeSearchResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Add support for highlight feature of elasticsearch @instification
 
+- Use _old_searchResults when patching safeSearchResults @instification
+
 ## 5.0.0 (2022-10-11)
 
 - Rename `master` branch to `main` @ericof

--- a/src/collective/elasticsearch/patches/__init__.py
+++ b/src/collective/elasticsearch/patches/__init__.py
@@ -23,7 +23,7 @@ def unrestrictedSearchResults(self, REQUEST=None, **kw):
 def safeSearchResults(self, REQUEST=None, **kw):
     manager = ElasticSearchManager()
     active = manager.active
-    method = manager.search_results if active else self._old_unrestrictedSearchResults
+    method = manager.search_results if active else self._old_searchResults
     return method(REQUEST, check_perms=True, **kw)
 
 


### PR DESCRIPTION
Fixes #104 