### PR TITLE
Misc improvements + bugfix if for example SearchableText is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Handle negative term filters (fixes #101) @instification
 
+- Add support for optional es host in worker via PLONE_ELASTICSEARCH_HOST env variable @maethu
+
 ## 5.0.0 (2022-10-11)
 
 - Rename `master` branch to `main` @ericof

--- a/setup.py
+++ b/setup.py
@@ -80,5 +80,7 @@ setup(
     entry_points="""
     [z3c.autoinclude.plugin]
     target = plone
+    [plone.autoinclude.plugin]
+    target = plone
     """,
 )

--- a/src/collective/elasticsearch/queueprocessor.py
+++ b/src/collective/elasticsearch/queueprocessor.py
@@ -228,7 +228,7 @@ class IndexProcessor:
                 if value in (None, "None"):
                     # yes, we'll index null data...
                     value = None
-            elif index_name in self._es_attributes:
+            elif index_name in self.es_attributes:
                 indexer = queryMultiAdapter(
                     (wrapped_object, catalog), IIndexer, name=index_name
                 )

--- a/src/collective/elasticsearch/redis/fetch.py
+++ b/src/collective/elasticsearch/redis/fetch.py
@@ -1,5 +1,3 @@
-from collective.elasticsearch import utils
-
 import io
 import os
 import requests
@@ -20,7 +18,8 @@ session_data.auth = (
 
 
 def fetch_data(uuid, attributes):
-    url = utils.PLONE_BACKEND + "/@elasticsearch_extractdata"
+    backend = os.environ.get("PLONE_BACKEND", None)
+    url = backend + "/@elasticsearch_extractdata"
     payload = {"uuid": uuid, "attributes:list": attributes}
     response = session.get(url, params=payload, verify=False, timeout=60)
     if response.status_code == 200:
@@ -32,8 +31,7 @@ def fetch_data(uuid, attributes):
 
 
 def fetch_blob_data(fieldname, data):
-    download_url = "/".join(
-        [utils.PLONE_BACKEND, data[fieldname]["path"], "@@download", fieldname]
-    )
+    backend = os.environ.get("PLONE_BACKEND", None)
+    download_url = "/".join([backend, data[fieldname]["path"], "@@download", fieldname])
     file_ = session_data.get(download_url)
     return io.BytesIO(file_.content)

--- a/src/collective/elasticsearch/redis/tasks.py
+++ b/src/collective/elasticsearch/redis/tasks.py
@@ -54,6 +54,7 @@ def bulk_update(hosts, params, index_name, body):
     """
     Collects all the data and updates elasticsearch
     """
+    hosts = os.environ.get("PLONE_ELASTICSEARCH_HOST", hosts)
     connection = es_connection(hosts, **params)
 
     for item in body:
@@ -81,6 +82,7 @@ def update_file_data(hosts, params, index_name, body):
     """
     Get blob data from plone and index it via elasticsearch attachment pipeline
     """
+    hosts = os.environ.get("PLONE_ELASTICSEARCH_HOST", hosts)
     connection = es_connection(hosts, **params)
     uuid, data = body
 

--- a/src/collective/elasticsearch/testing.py
+++ b/src/collective/elasticsearch/testing.py
@@ -55,12 +55,10 @@ class RedisElasticSearch(ElasticSearch):
         super().setUpPloneSite(portal)
 
         # Setup environ for redis testing
-        os.environ["PLONE_BACKEND"] = utils.PLONE_BACKEND = portal.absolute_url()
-        os.environ["PLONE_USERNAME"] = utils.PLONE_USERNAME = SITE_OWNER_NAME
-        os.environ["PLONE_PASSWORD"] = utils.PLONE_PASSWORD = SITE_OWNER_PASSWORD
-        os.environ[
-            "PLONE_REDIS_DSN"
-        ] = utils.PLONE_REDIS_DSN = "redis://localhost:6379/0"
+        os.environ["PLONE_BACKEND"] = portal.absolute_url()
+        os.environ["PLONE_USERNAME"] = SITE_OWNER_NAME
+        os.environ["PLONE_PASSWORD"] = SITE_OWNER_PASSWORD
+        os.environ["PLONE_REDIS_DSN"] = "redis://localhost:6379/0"
 
         # Make sure tasks are not handled async in tests
         # from collective.elasticsearch.redis.tasks import queue

--- a/src/collective/elasticsearch/tests/__init__.py
+++ b/src/collective/elasticsearch/tests/__init__.py
@@ -32,7 +32,7 @@ class BaseTest(unittest.TestCase):
         self.request.environ["testing"] = True
         self.app = self.layer["app"]
 
-        os.environ["PLONE_BACKEND"] = utils.PLONE_BACKEND = self.portal.absolute_url()
+        os.environ["PLONE_BACKEND"] = self.portal.absolute_url()
 
         settings = utils.get_settings()
         # disable sniffing hosts in tests because docker...

--- a/src/collective/elasticsearch/utils.py
+++ b/src/collective/elasticsearch/utils.py
@@ -20,12 +20,6 @@ except pkg_resources.DistributionNotFound:
     HAS_REDIS_MODULE = False
 
 
-PLONE_REDIS_DSN = os.environ.get("PLONE_REDIS_DSN", None)
-PLONE_USERNAME = os.environ.get("PLONE_USERNAME", None)
-PLONE_PASSWORD = os.environ.get("PLONE_PASSWORD", None)
-PLONE_BACKEND = os.environ.get("PLONE_BACKEND", None)
-
-
 def getUID(obj):
     value = IUUID(obj, None)
     if not value and hasattr(obj, "UID"):


### PR DESCRIPTION
- Use `es_attributes` instead of `_es_attributes`, since `_es_attributes` is only computed if `es_attributes` got accessed. -> This change makes it possible again to delete the ES Indexes.
- Add PLONE_ELASTICSEARCH_HOST env variable -> Possible to override this on more complex deployments
- Replace z3c.autoinclude with plone.autoinclude.
- And don's use/store the redis integration related variables in utils.py.