### PR TITLE
Check addon is installed before processing queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Handle negative term filters (fixes #101) @instification
 
+- Check addon is installed before processing queue (fixes #108) @instification
+
 ## 5.0.0 (2022-10-11)
 
 - Rename `master` branch to `main` @ericof

--- a/src/collective/elasticsearch/queueprocessor.py
+++ b/src/collective/elasticsearch/queueprocessor.py
@@ -89,6 +89,8 @@ class IndexProcessor:
 
     def index(self, obj, attributes=None):
         """Index the specified attributes for an obj."""
+        if not self.manager.active:
+            return
         actions = self.actions
         uuid, path = self._uuid_path(obj)
         actions.uuid_path[uuid] = path
@@ -122,10 +124,14 @@ class IndexProcessor:
 
     def reindex(self, obj, attributes=None, update_metadata=False):
         """Reindex the specified attributes for an obj."""
+        if not self.manager.active:
+            return
         self.index(obj, attributes)
 
     def unindex(self, obj):
         """Unindex the obj."""
+        if not self.manager.active:
+            return
         actions = self.actions
         uuid, path = self._uuid_path(obj)
         actions.uuid_path[uuid] = path


### PR DESCRIPTION
Fixes #108 

Checks the addon is installed (`self.manager.active`) before performing any queue processing.