### PR TITLE
Add support for multiple plone sites on one installation via PLONE_BACKEND_HOST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 - Add support for optional es host in worker via PLONE_ELASTICSEARCH_HOST env variable @maethu
 
+- Add support for multiple plone sites on one installation via PLONE_BACKEND_HOST @maethu
+
 
 ## 5.0.0 (2022-10-11)
 

--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,8 @@ setup(
         ],
     },
     entry_points="""
-    [z3c.autoinclude.plugin]
-    target = plone
     [plone.autoinclude.plugin]
     target = plone
+    module = collective.elasticsearch
     """,
 )

--- a/src/collective/elasticsearch/indexes.py
+++ b/src/collective/elasticsearch/indexes.py
@@ -284,6 +284,8 @@ class EExtendedPathIndex(BaseIndex):
             paths = [paths]
         andfilters = []
         for path in paths:
+            if isinstance(path, tuple) or isinstance(path, list):
+                path, depth = path
             spath = path.split("/")
             gtcompare = "gt"
             start = len(spath) - 1

--- a/src/collective/elasticsearch/indexes.py
+++ b/src/collective/elasticsearch/indexes.py
@@ -268,7 +268,7 @@ class EExtendedPathIndex(BaseIndex):
         return data[name]["path"]
 
     def get_query(self, name, value):
-        if isinstance(value, str):
+        if isinstance(value, str) or isinstance(value, list):
             paths = value
             depth = -1
             navtree = False

--- a/src/collective/elasticsearch/queueprocessor.py
+++ b/src/collective/elasticsearch/queueprocessor.py
@@ -276,7 +276,7 @@ class IndexProcessor:
                     value = indexer()
                 else:
                     attr = getattr(obj, index_name, None)
-                    value = attr() if callable(attr) else value
+                    value = attr() if callable(attr) else attr
             # Use str, if bytes value
             value = (
                 value.decode("utf-8", "ignore") if isinstance(value, bytes) else value

--- a/src/collective/elasticsearch/redis/fetch.py
+++ b/src/collective/elasticsearch/redis/fetch.py
@@ -17,9 +17,10 @@ session_data.auth = (
 )
 
 
-def fetch_data(uuid, attributes):
-    backend = os.environ.get("PLONE_BACKEND", None)
-    url = backend + "/@elasticsearch_extractdata"
+def fetch_data(plone_url, uuid, attributes):
+    if not plone_url:
+        plone_url = os.environ.get("PLONE_BACKEND", None)
+    url = plone_url + "/@elasticsearch_extractdata"
     payload = {"uuid": uuid, "attributes:list": attributes}
     response = session.get(url, params=payload, verify=False, timeout=60)
     if response.status_code == 200:
@@ -30,8 +31,11 @@ def fetch_data(uuid, attributes):
         raise Exception("Bad response from Plone Backend")
 
 
-def fetch_blob_data(fieldname, data):
-    backend = os.environ.get("PLONE_BACKEND", None)
-    download_url = "/".join([backend, data[fieldname]["path"], "@@download", fieldname])
+def fetch_blob_data(plone_url, fieldname, data):
+    if not plone_url:
+        plone_url = os.environ.get("PLONE_BACKEND", None)
+    download_url = "/".join(
+        [plone_url, data[fieldname]["path"], "@@download", fieldname]
+    )
     file_ = session_data.get(download_url)
     return io.BytesIO(file_.content)

--- a/src/collective/elasticsearch/redis/tasks.py
+++ b/src/collective/elasticsearch/redis/tasks.py
@@ -49,7 +49,7 @@ queue_low = Queue(
 )  # Don't queue in tests
 
 
-@job(queue, retry=Retry(max=3, interval=30))
+@job(queue, connection=queue.connection, retry=Retry(max=3, interval=30))
 def bulk_update(hosts, params, index_name, body, plone_url):
     """
     Collects all the data and updates elasticsearch
@@ -81,7 +81,7 @@ def bulk_update(hosts, params, index_name, body, plone_url):
     return "Done"
 
 
-@job(queue_low)
+@job(queue_low, connection=queue_low.connection)
 def update_file_data(hosts, params, index_name, body, plone_url):
     """
     Get blob data from plone and index it via elasticsearch attachment pipeline

--- a/src/collective/elasticsearch/redis/tasks.py
+++ b/src/collective/elasticsearch/redis/tasks.py
@@ -50,7 +50,7 @@ queue_low = Queue(
 
 
 @job(queue, retry=Retry(max=3, interval=30))
-def bulk_update(hosts, params, index_name, body):
+def bulk_update(hosts, params, index_name, body, plone_url):
     """
     Collects all the data and updates elasticsearch
     """
@@ -64,11 +64,15 @@ def bulk_update(hosts, params, index_name, body):
         catalog_info, payload = item
         action, index_info = list(catalog_info.items())[0]
         if action == "index":
-            data = fetch_data(uuid=index_info["_id"], attributes=list(payload.keys()))
+            data = fetch_data(
+                plone_url, uuid=index_info["_id"], attributes=list(payload.keys())
+            )
             item[1] = data
         elif action == "update":
             data = fetch_data(
-                uuid=index_info["_id"], attributes=list(payload["doc"].keys())
+                plone_url,
+                uuid=index_info["_id"],
+                attributes=list(payload["doc"].keys()),
             )
             item[1]["doc"] = data
 
@@ -78,7 +82,7 @@ def bulk_update(hosts, params, index_name, body):
 
 
 @job(queue_low)
-def update_file_data(hosts, params, index_name, body):
+def update_file_data(hosts, params, index_name, body, plone_url):
     """
     Get blob data from plone and index it via elasticsearch attachment pipeline
     """
@@ -89,7 +93,7 @@ def update_file_data(hosts, params, index_name, body):
     attachments = {"attachments": []}
 
     for fieldname, content in data.items():
-        file_ = fetch_blob_data(fieldname, data)
+        file_ = fetch_blob_data(plone_url, fieldname, data)
         attachments["attachments"].append(
             {
                 "filename": content["filename"],

--- a/src/collective/elasticsearch/redis/tasks.py
+++ b/src/collective/elasticsearch/redis/tasks.py
@@ -81,7 +81,6 @@ def bulk_update(hosts, params, index_name, body, plone_url):
     return "Done"
 
 
-
 @job(queue_low, connection=queue_low.connection)
 def update_file_data(hosts, params, index_name, body, plone_url):
     """

--- a/src/collective/elasticsearch/utils.py
+++ b/src/collective/elasticsearch/utils.py
@@ -82,14 +82,17 @@ def format_size_mb(value: int) -> str:
 
 def is_redis_available():
     """Determens if redis could be available"""
-    env_variables = [
+    env_variables_required = [
         HAS_REDIS_MODULE,
         os.environ.get("PLONE_REDIS_DSN", None),
         os.environ.get("PLONE_USERNAME", None),
         os.environ.get("PLONE_PASSWORD", None),
-        os.environ.get("PLONE_BACKEND", None),
     ]
-    return all(env_variables)
+    env_any_required = [
+        os.environ.get("PLONE_BACKEND", None),
+        os.environ.get("PLONE_BACKEND_HOST", None),
+    ]
+    return all(env_variables_required) and any(env_any_required)
 
 
 def use_redis():


### PR DESCRIPTION
In order to support multiple Plone sites on one zope instance. This PR introduces the `PLONE_BACKEND_HOST` env variable. 

Details:
- If PLONE_BACKEND_HOST is set, the PLONE_BACKEND env variable is ignored.
- The PLONE_BACKEND_HOST needs to point to the root of the zope instance.
- The URL to the Plone site is computed in the ES manager (Where we have access to the plone context)