### PR TITLE
Support Elasticsearch 8 along with Elasticsearch 7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,13 +31,13 @@ jobs:
       # git checkout
       - uses: actions/checkout@v2
 
-      - name: Setup elasticsearch docker container with ingest attachment plugin
+      - name: Setup elasticsearch 7.17.7 docker container with ingest attachment plugin
         run: |
           docker container create --name elastictest \
           -e "discovery.type=single-node" \
           -e "cluster.name=docker-cluster" \
           -e "http.cors.enabled=true" \
-          -e "http.cors.allow-origin=*" \
+          -e "http.cors.allow-origin='*'" \
           -e "http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization" \
           -e "http.cors.allow-credentials=true" \
           -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
@@ -57,9 +57,32 @@ jobs:
 
       - name: Install package
         run: |
-          pip install -e ".[test, redis]"
+          pip install -e ".[test, redis]" elasticsearch==7.17.7
 
-      # test
-      - name: test
+      # test elasticsearch 7.17.7
+      - name: test elasticsearch 7.17.7
         run: |
+          zope-testrunner --auto-color --auto-progress --test-path src; \
+          docker stop elastictest; \
+          docker rm elastictest
+
+      # test elasticsearch 8.10.2
+      - name: Setup elasticsearch 8.10.2 docker container
+        run: |
+          docker container create --name elastictest8 \
+          -e "discovery.type=single-node" \
+          -e "cluster.name=docker-cluster" \
+          -e "http.cors.enabled=true" \
+          -e "http.cors.allow-origin='*'" \
+          -e "http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization" \
+          -e "http.cors.allow-credentials=true" \
+          -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
+          -p 9200:9200 \
+          -p 9300:9300 \
+          elasticsearch:8.10.2; \
+          docker start elastictest8; \
+
+      - name: test elasticsearch 8.10.2
+        run: |
+          pip install elasticsearch==8.10.0; /
           zope-testrunner --auto-color --auto-progress --test-path src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.1.0 (unreleased)
+
+- Add suport of elasticsearch to 8.10.2 @maethu
+
 ## 5.0.1 (unreleased)
 
 - Update elasticsearch to 7.17.7 (Ready for 8.x and apple silicon images are available) @maethu

--- a/README.md
+++ b/README.md
@@ -263,6 +263,14 @@ make format
 make lint
 ```
 
+# Upgrade from elasticsearch 7.17.7 to 8.10.x
+
+I you were already on elasticsearch 7.17.7 there is usually not mutch you need to do with elasticsearch itself. I will update itself automatically, once you update to elasticsearch 8 and restart the service.
+
+- If there is a configuration issue creating the new elasticsearch 8 container, make sure you have single or douple quotes around certain values. Like change http.cors.allow-origin=* to http.cors.allow-origin="*".
+- Add port to all hosts in the control panel hosts section. If there is no port defined we add port 9200 by default if you are running elasticsearch 8.
+- Please check the elasticsearch upgrade guide https://www.elastic.co/guide/en/elastic-stack/8.10/upgrading-elastic-stack.html#prepare-to-upgrade
+
 ## License
 
 The project is licensed under the GPLv2.

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -20,9 +20,10 @@ services:
       - discovery.type=single-node
       - cluster.name=docker-cluster
       - http.cors.enabled=true
-      - http.cors.allow-origin=*
+      - http.cors.allow-origin="*"
       - http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
       - http.cors.allow-credentials=true
+      - xpack.security.enabled=false
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data
@@ -36,6 +37,7 @@ services:
       - PLONE_BACKEND=http://plone:8080/Plone
       - PLONE_USERNAME=admin
       - PLONE_PASSWORD=admin
+      - PLONE_ELASTICSEARCH_HOST=host.docker.internal
 
   plone:
     build:

--- a/docker/elasticsearch.Dockerfile
+++ b/docker/elasticsearch.Dockerfile
@@ -1,3 +1,3 @@
-FROM elasticsearch:7.17.7
+FROM elasticsearch:8.10.2
 
 RUN bin/elasticsearch-plugin install ingest-attachment -b

--- a/docker/plone.Dockerfile
+++ b/docker/plone.Dockerfile
@@ -1,8 +1,8 @@
-FROM plone/plone-backend:6.0.0b3
+FROM plone/plone-backend:6.0.7
 
 WORKDIR /app
 
-RUN /app/bin/pip install git+https://github.com/collective/collective.elasticsearch.git@mle-redis-rq#egg=collective.elasticsearch[redis]
+RUN /app/bin/pip install git+https://github.com/collective/collective.elasticsearch.git@main#egg=collective.elasticsearch[redis]
 
 ENV PROFILES="collective.elasticsearch:default collective.elasticsearch:docker-dev"
 ENV TYPE="classic"

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -1,7 +1,7 @@
-FROM plone/plone-backend:6.0.0b3
+FROM plone/plone-backend:6.0.7
 
 WORKDIR /app
 
-RUN /app/bin/pip install git+https://github.com/collective/collective.elasticsearch.git@mle-redis-rq#egg=collective.elasticsearch[redis]
+RUN /app/bin/pip install git+https://github.com/collective/collective.elasticsearch.git@main#egg=collective.elasticsearch[redis]
 
 CMD /app/bin/rq worker normal low --with-scheduler --url=$PLONE_REDIS_DSN

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "setuptools",
-        "elasticsearch==7.17.7",
+        "elasticsearch==7.17.7, 8.10.0",
         "plone.app.registry",
         "plone.api",
         "setuptools",

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "setuptools",
-        "elasticsearch==7.17.7, 8.10.0",
+        "elasticsearch>=7.17.7, <=8.10.0",
         "plone.app.registry",
         "plone.api",
         "setuptools",

--- a/src/collective/elasticsearch/browser/controlpanel.py
+++ b/src/collective/elasticsearch/browser/controlpanel.py
@@ -1,6 +1,7 @@
 from collective.elasticsearch.interfaces import IElasticSettings
 from collective.elasticsearch.manager import ElasticSearchManager
 from collective.elasticsearch.utils import is_redis_available
+from elastic_transport import ConnectionTimeout
 from elasticsearch.exceptions import ConnectionError as conerror
 from plone import api
 from plone.app.registry.browser.controlpanel import ControlPanelFormWrapper
@@ -52,6 +53,7 @@ class ElasticControlPanelFormWrapper(ControlPanelFormWrapper):
             except (
                 conerror,
                 ConnectionError,
+                ConnectionTimeout,
                 NewConnectionError,
                 ConnectionRefusedError,
                 AttributeError,
@@ -60,7 +62,10 @@ class ElasticControlPanelFormWrapper(ControlPanelFormWrapper):
 
     @property
     def es_info(self):
-        return self.es.info
+        try:
+            return self.es.info
+        except ConnectionTimeout:
+            return None
 
     @property
     def enabled(self):

--- a/src/collective/elasticsearch/interfaces.py
+++ b/src/collective/elasticsearch/interfaces.py
@@ -57,7 +57,7 @@ class IElasticSettings(Interface):
 
     hosts = schema.List(
         title="Hosts",
-        default=["127.0.0.1"],
+        default=["http://127.0.0.1:9200"],
         unique=True,
         value_type=schema.TextLine(title="Host"),
     )

--- a/src/collective/elasticsearch/interfaces.py
+++ b/src/collective/elasticsearch/interfaces.py
@@ -1,3 +1,4 @@
+from collective.elasticsearch.utils import ELASTIC_SEARCH_VERSION
 from dataclasses import dataclass
 from Products.CMFCore.interfaces import IIndexQueueProcessor
 from typing import Dict
@@ -57,7 +58,7 @@ class IElasticSettings(Interface):
 
     hosts = schema.List(
         title="Hosts",
-        default=["http://127.0.0.1:9200"],
+        default=ELASTIC_SEARCH_VERSION == 8 and ["http://127.0.0.1:9200"] or ["127.0.0.1"],
         unique=True,
         value_type=schema.TextLine(title="Host"),
     )

--- a/src/collective/elasticsearch/manager.py
+++ b/src/collective/elasticsearch/manager.py
@@ -4,6 +4,7 @@ from collective.elasticsearch import logger
 from collective.elasticsearch import utils
 from collective.elasticsearch.result import BrainFactory
 from collective.elasticsearch.result import ElasticResult
+from collective.elasticsearch.utils import ELASTIC_SEARCH_VERSION
 from collective.elasticsearch.utils import use_redis
 from DateTime import DateTime
 from elasticsearch import Elasticsearch
@@ -233,7 +234,8 @@ class ElasticSearchManager:
         actual binary data is available to extract.
         """
 
-        if "attachment" not in self.connection.cat.plugins():
+        if (ELASTIC_SEARCH_VERSION == 7 and
+                "attachment" not in self.connection.cat.plugins()):
             return
 
         body = {
@@ -247,7 +249,7 @@ class ElasticSearchManager:
                             "attachment": {
                                 "target_field": "_ingest._value.attachment",
                                 "field": "_ingest._value.data",
-                                # "remove_binary": "true",  # version 8
+                                "remove_binary": True,  # version 8
                                 "properties": ["content"],
                             }
                         },
@@ -262,7 +264,9 @@ class ElasticSearchManager:
                                     if (ctx['attachments'][i]['attachment']['content'].length() > 0) {
                                         ctx['SearchableText'] += ctx['attachments'][i]['attachment']['content'];
                                     }
-                                    ctx['attachments'][i]['data'] = null;
+                                    if (ctx['attachments'][i].containsKey('data')) {
+                                        ctx['attachments'][i]['data'] = null;
+                                    }                                   
                                 }
                             }
                             """,

--- a/src/collective/elasticsearch/mapping.py
+++ b/src/collective/elasticsearch/mapping.py
@@ -48,7 +48,7 @@ class MappingAdapter:
 
         conn = manager.connection
         index_name = manager.index_name
-        if conn.indices.exists(index_name):
+        if conn.indices.exists(index=index_name):
             # created BEFORE we started creating this as aliases to versions,
             # we can't go anywhere from here beside try updating...
             pass
@@ -57,8 +57,10 @@ class MappingAdapter:
                 # need to initialize version value
                 manager._bump_index_version()
             index_name_v = f"{index_name}_{manager.index_version}"
-            if not conn.indices.exists(index_name_v):
-                conn.indices.create(index_name_v, body=self.get_index_creation_body())
+            if not conn.indices.exists(index=index_name_v):
+                conn.indices.create(
+                    index=index_name_v, body=self.get_index_creation_body()
+                )
             if not conn.indices.exists_alias(name=index_name):
                 conn.indices.put_alias(index=index_name_v, name=index_name)
 

--- a/src/collective/elasticsearch/redis/fetch.py
+++ b/src/collective/elasticsearch/redis/fetch.py
@@ -27,7 +27,9 @@ def fetch_data(uuid, attributes):
         if "@id" in content and "data" in content:
             return content["data"]
     else:
-        raise Exception("Bad response from Plone Backend")
+        raise Exception(
+            f"Bad response from Plone Backend: {response.status_code} \n {response.content}"
+        )
 
 
 def fetch_blob_data(fieldname, data):

--- a/src/collective/elasticsearch/redis/tasks.py
+++ b/src/collective/elasticsearch/redis/tasks.py
@@ -73,7 +73,7 @@ def bulk_update(hosts, params, index_name, body):
             item[1]["doc"] = data
 
     es_data = [item for sublist in body for item in sublist]
-    connection.bulk(index=index_name, body=es_data)
+    connection.bulk(index=index_name, operations=es_data)
     return "Done"
 
 

--- a/src/collective/elasticsearch/redis/tasks.py
+++ b/src/collective/elasticsearch/redis/tasks.py
@@ -74,7 +74,10 @@ def bulk_update(hosts, params, index_name, body):
             item[1]["doc"] = data
 
     es_data = [item for sublist in body for item in sublist]
-    connection.bulk(index=index_name, operations=es_data)
+    if ELASTIC_SEARCH_VERSION == 8:
+        connection.bulk(index=index_name, operations=es_data)
+    else:
+        connection.bulk(es_data, index=index_name)
     return "Done"
 
 

--- a/src/collective/elasticsearch/redis/tasks.py
+++ b/src/collective/elasticsearch/redis/tasks.py
@@ -2,6 +2,7 @@ from .fetch import fetch_blob_data
 from .fetch import fetch_data
 from collective.elasticsearch import local
 from collective.elasticsearch.manager import ElasticSearchManager
+from collective.elasticsearch.utils import ELASTIC_SEARCH_VERSION
 from elasticsearch import Elasticsearch
 from rq import Queue
 from rq import Retry
@@ -83,7 +84,15 @@ def update_file_data(hosts, params, index_name, body):
     Get blob data from plone and index it via elasticsearch attachment pipeline
     """
     hosts = os.environ.get("PLONE_ELASTICSEARCH_HOST", hosts)
-    connection = es_connection(hosts, **params)
+
+    if ELASTIC_SEARCH_VERSION == 8:
+        serializers = {
+            "application/cbor": cbor2,
+        }
+        params["serializers"] = serializers
+        connection = Elasticsearch(hosts, **params)
+    else:
+        connection = es_connection(hosts, **params)
     uuid, data = body
 
     attachments = {"attachments": []}

--- a/src/collective/elasticsearch/tests/__init__.py
+++ b/src/collective/elasticsearch/tests/__init__.py
@@ -35,10 +35,18 @@ class BaseTest(unittest.TestCase):
         os.environ["PLONE_BACKEND"] = self.portal.absolute_url()
 
         settings = utils.get_settings()
-        # disable sniffing hosts in tests because docker...
-        settings.sniffer_timeout = None
         settings.enabled = True
-        settings.sniffer_timeout = 0.0
+
+        # Elasticsearch 8 requires a sniffing timeout, otherwise the python
+        # ES client tries to sniff first even though the new ES instance with
+        # index is not yet initialized.
+
+        # This means, basically never sniff during tests
+        # Since it's a single instance installation in tests sniffing does not
+        # make sense anyway.
+
+        # With ES 7 setting 0.0 was enough
+        settings.sniffer_timeout = 10000.0
 
         # Raise elastic search exceptions
         settings.raise_search_exception = True

--- a/src/collective/elasticsearch/utils.py
+++ b/src/collective/elasticsearch/utils.py
@@ -27,6 +27,11 @@ def getUID(obj):
     return value
 
 
+ELASTIC_SEARCH_VERSION = pkg_resources.get_distribution(
+    "elasticsearch"
+).parsed_version.major
+
+
 def get_brain_from_path(zcatalog: ZCatalog, path: str) -> AbstractCatalogBrain:
     rid = zcatalog.uids.get(path)
     if isinstance(rid, int):

--- a/src/collective/elasticsearch/utils.py
+++ b/src/collective/elasticsearch/utils.py
@@ -51,11 +51,19 @@ def get_settings():
 
 def get_connection_settings():
     settings = get_settings()
-    return settings.hosts, {
+
+    hosts = settings.hosts
+    if ELASTIC_SEARCH_VERSION == 8:
+        # Make sure the is a port defined for all hosts
+        for index, host in enumerate(settings.hosts):
+            if ":" not in host:
+                hosts[index] = f"{host}:9200"
+
+    return hosts, {
         "retry_on_timeout": settings.retry_on_timeout,
         "sniff_on_connection_fail": settings.sniff_on_connection_fail,
         "sniff_on_start": settings.sniff_on_start,
-        "sniffer_timeout": settings.sniffer_timeout,
+        "sniffer_timeout": settings.sniffer_timeout and settings.sniffer_timeout or 0.0,
         "timeout": settings.timeout,
     }
 

--- a/src/collective/elasticsearch/utils.py
+++ b/src/collective/elasticsearch/utils.py
@@ -1,5 +1,4 @@
 from collective.elasticsearch import logger
-from collective.elasticsearch.interfaces import IElasticSettings
 from plone.registry.interfaces import IRegistry
 from plone.uuid.interfaces import IUUID
 from Products.ZCatalog import ZCatalog
@@ -46,6 +45,8 @@ def get_brain_from_path(zcatalog: ZCatalog, path: str) -> AbstractCatalogBrain:
 
 def get_settings():
     """Return IElasticSettings values."""
+    from collective.elasticsearch.interfaces import IElasticSettings
+
     registry = getUtility(IRegistry)
     try:
         settings = registry.forInterface(IElasticSettings, check=False)
@@ -62,7 +63,7 @@ def get_connection_settings():
         # Make sure the is a port defined for all hosts
         for index, host in enumerate(settings.hosts):
             if ":" not in host:
-                hosts[index] = f"{host}:9200"
+                hosts[index] = f"http://{host}:9200"
 
     return hosts, {
         "retry_on_timeout": settings.retry_on_timeout,


### PR DESCRIPTION
This might be an overkill and maybe it make sense to only support 1 major release of elasticsearch. 
But here we go...

Changes:
- [X] Extend make file to be able to support ES 7 or ES 8
- [X] Add compatibility for elasticsearch-py 7.17.x and 8.10.x
- [X] Adapt attachment text extraction for ES 8 (Actually simpler, since it's in the core now and no longer a plugin)
- [X] Small code improvements
- [ ] Adapt sniffing for ES 8

