### PR TITLE
Add configurable query types. Create new simple query string option

### DIFF
--- a/src/collective/elasticsearch/indexes.py
+++ b/src/collective/elasticsearch/indexes.py
@@ -218,8 +218,8 @@ class EZCTextIndex(BaseIndex):
     def get_query(self, name, value):
         value = self._normalize_query(value)
         # ES doesn't care about * like zope catalog does
-        clean_value = value.strip("*") if value else ""
         if self.query_type == "match":
+            clean_value = value.strip("*") if value else ""
             queries = [{"match_phrase": {name: {"query": clean_value, "slop": 2}}}]
             if name in ("Title", "SearchableText"):
                 # titles have most importance... we override here...
@@ -232,7 +232,7 @@ class EZCTextIndex(BaseIndex):
             return queries
 
         if self.query_type == "simple_query_string":
-            qs_value = self._make_simple_query_string(clean_value)
+            qs_value = self._make_simple_query_string(value)
 
             fields = []
             if name in ("Title", "SearchableText"):

--- a/src/collective/elasticsearch/indexes.py
+++ b/src/collective/elasticsearch/indexes.py
@@ -59,9 +59,10 @@ keyword_fields = (
 class BaseIndex:
     filter_query = True
 
-    def __init__(self, catalog, index):
+    def __init__(self, catalog, index, query_type="match"):
         self.catalog = catalog
         self.index = index
+        self.query_type = query_type
 
     def create_mapping(self, name):  # NOQA R0201
         if name in keyword_fields:
@@ -209,20 +210,43 @@ class EZCTextIndex(BaseIndex):
             return "\n".join(all_texts)
         return None
 
+    def _make_simple_query_string(self, query):
+        query = query.replace(" AND ", " + ")
+        return query
+
+
     def get_query(self, name, value):
         value = self._normalize_query(value)
         # ES doesn't care about * like zope catalog does
         clean_value = value.strip("*") if value else ""
-        queries = [{"match_phrase": {name: {"query": clean_value, "slop": 2}}}]
-        if name in ("Title", "SearchableText"):
-            # titles have most importance... we override here...
-            queries.append(
-                {"match_phrase_prefix": {"Title": {"query": clean_value, "boost": 2}}}
-            )
-        if name != "Title":
-            queries.append({"match": {name: {"query": clean_value}}})
+        if self.query_type == "match":
+            queries = [{"match_phrase": {name: {"query": clean_value, "slop": 2}}}]
+            if name in ("Title", "SearchableText"):
+                # titles have most importance... we override here...
+                queries.append(
+                    {"match_phrase_prefix": {"Title": {"query": clean_value, "boost": 2}}}
+                )
+            if name != "Title":
+                queries.append({"match": {name: {"query": clean_value}}})
 
-        return queries
+            return queries
+
+        if self.query_type == "simple_query_string":
+            qs_value = self._make_simple_query_string(clean_value)
+
+            fields = []
+            if name in ("Title", "SearchableText"):
+                fields.extend(["Title^2", "SearchableText"])
+            else:
+                fields.append(name)
+            query = {
+                "simple_query_string": {
+                    "query":  qs_value,
+                    "fields": fields
+                }
+            }
+            return query
+
 
 
 class EBooleanIndex(BaseIndex):
@@ -381,7 +405,7 @@ except ImportError:
     pass
 
 
-def getIndex(catalog, name):
+def getIndex(catalog, name, query_type="match"):
     catalog = getattr(catalog, "_catalog", catalog)
     try:
         index = aq_base(catalog.getIndex(name))
@@ -389,5 +413,5 @@ def getIndex(catalog, name):
         return None
     index_type = type(index)
     if index_type in INDEX_MAPPING:
-        return INDEX_MAPPING[index_type](catalog, index)
+        return INDEX_MAPPING[index_type](catalog, index, query_type=query_type)
     return None

--- a/src/collective/elasticsearch/indexes.py
+++ b/src/collective/elasticsearch/indexes.py
@@ -214,7 +214,6 @@ class EZCTextIndex(BaseIndex):
         query = query.replace(" AND ", " + ")
         return query
 
-
     def get_query(self, name, value):
         value = self._normalize_query(value)
         # ES doesn't care about * like zope catalog does
@@ -224,7 +223,11 @@ class EZCTextIndex(BaseIndex):
             if name in ("Title", "SearchableText"):
                 # titles have most importance... we override here...
                 queries.append(
-                    {"match_phrase_prefix": {"Title": {"query": clean_value, "boost": 2}}}
+                    {
+                        "match_phrase_prefix": {
+                            "Title": {"query": clean_value, "boost": 2}
+                        }
+                    }
                 )
             if name != "Title":
                 queries.append({"match": {name: {"query": clean_value}}})
@@ -239,14 +242,8 @@ class EZCTextIndex(BaseIndex):
                 fields.extend(["Title^2", "SearchableText"])
             else:
                 fields.append(name)
-            query = {
-                "simple_query_string": {
-                    "query":  qs_value,
-                    "fields": fields
-                }
-            }
+            query = {"simple_query_string": {"query": qs_value, "fields": fields}}
             return query
-
 
 
 class EBooleanIndex(BaseIndex):

--- a/src/collective/elasticsearch/interfaces.py
+++ b/src/collective/elasticsearch/interfaces.py
@@ -5,6 +5,12 @@ from typing import List
 from typing import Tuple
 from zope import schema
 from zope.interface import Interface
+from zope.schema.vocabulary import SimpleVocabulary
+from zope.schema.vocabulary import SimpleTerm
+
+query_types = SimpleVocabulary([
+    SimpleTerm(value=u'match', title=u'Match (Default)'),
+    SimpleTerm(value=u'simple_query_string', title=u'Simple Query String')])
 
 
 class IElasticSearchLayer(Interface):
@@ -66,6 +72,13 @@ class IElasticSettings(Interface):
         title="Indexes for which all searches are done through ElasticSearch",
         default={"Title", "Description", "SearchableText"},
         value_type=schema.TextLine(title="Index"),
+    )
+
+    query_type = schema.Choice(
+        title=u'Query Type',
+        description="Whether to use match/match_prefix queries or simple_query_string queries. See elastic search docs for more information.",
+        default=u'match',
+        vocabulary=query_types
     )
 
     sniff_on_start = schema.Bool(title="Sniff on start", default=False, required=False)

--- a/src/collective/elasticsearch/interfaces.py
+++ b/src/collective/elasticsearch/interfaces.py
@@ -5,12 +5,16 @@ from typing import List
 from typing import Tuple
 from zope import schema
 from zope.interface import Interface
-from zope.schema.vocabulary import SimpleVocabulary
 from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
 
-query_types = SimpleVocabulary([
-    SimpleTerm(value=u'match', title=u'Match (Default)'),
-    SimpleTerm(value=u'simple_query_string', title=u'Simple Query String')])
+
+query_types = SimpleVocabulary(
+    [
+        SimpleTerm(value="match", title="Match (Default)"),
+        SimpleTerm(value="simple_query_string", title="Simple Query String"),
+    ]
+)
 
 
 class IElasticSearchLayer(Interface):
@@ -75,10 +79,10 @@ class IElasticSettings(Interface):
     )
 
     query_type = schema.Choice(
-        title=u'Query Type',
+        title="Query Type",
         description="Whether to use match/match_prefix queries or simple_query_string queries. See elastic search docs for more information.",
-        default=u'match',
-        vocabulary=query_types
+        default="match",
+        vocabulary=query_types,
     )
 
     sniff_on_start = schema.Bool(title="Sniff on start", default=False, required=False)

--- a/src/collective/elasticsearch/manager.py
+++ b/src/collective/elasticsearch/manager.py
@@ -104,6 +104,19 @@ class ElasticSearchManager:
         return value
 
     @property
+    def query_type(self):
+        """Query type chosen."""
+        try:
+            value = api.portal.get_registry_record(
+                "query_type", interfaces.IElasticSettings, "match"
+            )
+        except KeyError:
+            value = "match"
+        if value is None:
+            value = "match"
+        return value
+
+    @property
     def catalog(self):
         return api.portal.get_tool("portal_catalog")
 
@@ -367,6 +380,7 @@ class ElasticSearchManager:
                 "pre_tags": self.highlight_pre_tags.split("\n"),
                 "post_tags": self.highlight_post_tags.split("\n"),
             }
+        import json; print(json.dumps(body, indent=4))
         return self.connection.search(index=self.index_name, body=body, **query_params)
 
     def search(self, query: dict, factory=None, **query_params) -> LazyMap:

--- a/src/collective/elasticsearch/manager.py
+++ b/src/collective/elasticsearch/manager.py
@@ -380,7 +380,9 @@ class ElasticSearchManager:
                 "pre_tags": self.highlight_pre_tags.split("\n"),
                 "post_tags": self.highlight_post_tags.split("\n"),
             }
-        import json; print(json.dumps(body, indent=4))
+        import json
+
+        print(json.dumps(body, indent=4))
         return self.connection.search(index=self.index_name, body=body, **query_params)
 
     def search(self, query: dict, factory=None, **query_params) -> LazyMap:

--- a/src/collective/elasticsearch/query.py
+++ b/src/collective/elasticsearch/query.py
@@ -39,15 +39,16 @@ class QueryAssembler:
         matches = []
         catalog = self.catalog._catalog
         idxs = catalog.indexes.keys()
+        query_type = self.es.query_type
         query = {"match_all": {}}
         es_only_indexes = getESOnlyIndexes()
         for key, value in dquery.items():
             if key not in idxs and key not in es_only_indexes:
                 continue
-            index = getIndex(catalog, key)
+            index = getIndex(catalog, key, query_type=query_type)
             if index is None and key in es_only_indexes:
                 # deleted index for plone performance but still need on ES
-                index = EZCTextIndex(catalog, key)
+                index = EZCTextIndex(catalog, key, query_type=query_type)
             qq = index.get_query(key, value)
             if qq is None:
                 continue


### PR DESCRIPTION
At present searches are constructed as [match queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html)

However, for various reasons users may wish to incorporate advanced query types such as [simple query string](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html)

This PR enables configurable search functionality in a backwards compatible way by:

 - Creating a new "Query Type" configuration option
   - Defaults to "Match" which is the existing behaviour of collective.elasticsearch
 - Creating a new Query type option of "Simple Query String"
 
The work in this PR can also be extended in future to incorporate many different [full text queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/full-text-queries.html)

# Tasks

 - [x] Add query type option
 - [x] Add new simple query string option
 - [ ] Write tests
 - [ ] Changelog/docs 