### PR TITLE
Create custom serializer to handle set() index data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 - Add support for optional es host in worker via PLONE_ELASTICSEARCH_HOST env variable @maethu
 
+- Serialize to list when indexed data contains sets @instification
+
 
 ## 5.0.0 (2022-10-11)
 

--- a/src/collective/elasticsearch/manager.py
+++ b/src/collective/elasticsearch/manager.py
@@ -6,7 +6,7 @@ from collective.elasticsearch.result import BrainFactory
 from collective.elasticsearch.result import ElasticResult
 from collective.elasticsearch.utils import use_redis
 from DateTime import DateTime
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, JSONSerializer
 from elasticsearch import exceptions
 from elasticsearch.exceptions import NotFoundError
 from plone import api
@@ -25,6 +25,14 @@ import warnings
 CONVERTED_ATTR = "_elasticconverted"
 CUSTOM_INDEX_NAME_ATTR = "_elasticcustomindex"
 INDEX_VERSION_ATTR = "_elasticindexversion"
+
+# Custom serializer to handle cases where set() data is passed to an index
+class PloneJSONSerializer(JSONSerializer):
+
+    def default(self, data):
+        if isinstance(data, set):
+            return [i for i in data]
+        super().default(data)
 
 
 @implementer(interfaces.IElasticSearchManager)
@@ -288,7 +296,7 @@ class ElasticSearchManager:
         conn = local.get_local(self.connection_key)
         if not conn:
             hosts, params = utils.get_connection_settings()
-            local.set_local(self.connection_key, Elasticsearch(hosts, **params))
+            local.set_local(self.connection_key, Elasticsearch(hosts, serializer=PloneJSONSerializer(), **params))
             conn = local.get_local(self.connection_key)
         return conn
 

--- a/src/collective/elasticsearch/redis/tasks.py
+++ b/src/collective/elasticsearch/redis/tasks.py
@@ -1,7 +1,7 @@
 from .fetch import fetch_blob_data
 from .fetch import fetch_data
 from collective.elasticsearch import local
-from collective.elasticsearch.manager import ElasticSearchManager
+from collective.elasticsearch.manager import ElasticSearchManager, PloneJSONSerializer
 from elasticsearch import Elasticsearch
 from rq import Queue
 from rq import Retry
@@ -30,7 +30,7 @@ def es_connection(hosts, **params):
     connection = local.get_local(ElasticSearchManager.connection_key)
     if not connection:
         local.set_local(
-            ElasticSearchManager.connection_key, Elasticsearch(hosts, **params)
+            ElasticSearchManager.connection_key, Elasticsearch(hosts, serializer=PloneJSONSerializer(), **params)
         )
         connection = local.get_local(ElasticSearchManager.connection_key)
     return connection


### PR DESCRIPTION
Fixes #116 

This PR creates a custom JSON serializer which creates a list from sets when indexing data.

The elastic search serializer code is here: https://github.com/elastic/elasticsearch-py/blob/main/elasticsearch/serializer.py#L60
