### PR TITLE
Fire BlobIndexJobCreated event after blob extraction job is enqueued

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,13 +7,13 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.8", "3.10", "3.11"]
-        plone: ["5.2-latest", "6.0-latest"]
+        plone: ["5.2-latest", "6.2-latest"]
         exclude:
           - plone: "5.2-latest"
             python: "3.10"
           - plone: "5.2-latest"
             python: "3.11"
-          - plone: "6.0-latest"
+          - plone: "6.2-latest"
             python: "3.8"
 
     services:
@@ -79,13 +79,13 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.8", "3.10", "3.11"]
-        plone: ["5.2-latest", "6.0-latest"]
+        plone: ["5.2-latest", "6.2-latest"]
         exclude:
           - plone: "5.2-latest"
             python: "3.10"
           - plone: "5.2-latest"
             python: "3.11"
-          - plone: "6.0-latest"
+          - plone: "6.2-latest"
             python: "3.8"
 
     services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 6.0.0 (unreleased)
 
+- Fire BlobIndexJobCreated event after blob extraction job is enqueued, allowing downstream packages to chain dependent jobs via RQ's depends_on @maethu
+
 - Update elasticsearch to 7.17.7 (Ready for 8.x and apple silicon images are available) @maethu
 
 - Control-Panel: Fix potential issue with bool fields @maethu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 6.0.0 (unreleased)
 
+- Run tests against Plone 6.2 @maethu
+
 - Fire BlobIndexJobCreated event after blob extraction job is enqueued, allowing downstream packages to chain dependent jobs via RQ's depends_on @maethu
 
 - Update elasticsearch to 7.17.7 (Ready for 8.x and apple silicon images are available) @maethu

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ RESET=`tput sgr0`
 YELLOW=`tput setaf 3`
 
 PLONE5=5.2-latest
-PLONE6=6.0-latest
+PLONE6=6.2-latest
 
 INSTANCE_YAML=instance.yaml
 
@@ -83,15 +83,15 @@ build-plone-5: bin/pip ## Build Plone 5.2
 	make instance
 
 .PHONY: build-plone-6
-build-plone-6: bin/pip ## Build Plone 6.0
-	@echo "$(GREEN)==> Build with Plone 6.0$(RESET)"
+build-plone-6: bin/pip ## Build Plone 6.2
+	@echo "$(GREEN)==> Build with Plone 6.2$(RESET)"
 	bin/pip install Plone -c https://dist.plone.org/release/$(PLONE6)/constraints.txt
 	bin/pip install "zest.releaser[recommended]"
 	bin/pip install -e ".[test, redis]"
 	make instance
 
 .PHONY: build
-build: build-plone-6 ## Build Plone 6.0
+build: build-plone-6 ## Build Plone 6.2
 
 .PHONY: clean
 clean: ## Remove old virtualenv and creates a new one

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/src/collective/elasticsearch/events.py
+++ b/src/collective/elasticsearch/events.py
@@ -1,0 +1,19 @@
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+class IBlobIndexJobCreated(Interface):
+    """Fired after a blob extraction job has been enqueued."""
+
+
+@implementer(IBlobIndexJobCreated)
+class BlobIndexJobCreated:
+    """Fired after a blob extraction job has been enqueued.
+
+    Subscribers can use ``event.job`` with RQ's ``depends_on`` to
+    chain work that needs the extracted text.
+    """
+
+    def __init__(self, uid, job):
+        self.uid = uid
+        self.job = job

--- a/src/collective/elasticsearch/manager.py
+++ b/src/collective/elasticsearch/manager.py
@@ -8,6 +8,7 @@ from collective.elasticsearch.compat import has_attachment_processor
 from collective.elasticsearch.compat import indices_put_mapping
 from collective.elasticsearch.compat import indices_put_settings
 from collective.elasticsearch.compat import ingest_put_pipeline
+from collective.elasticsearch.events import BlobIndexJobCreated
 from collective.elasticsearch.result import BrainFactory
 from collective.elasticsearch.result import ElasticResult
 from collective.elasticsearch.utils import use_redis
@@ -21,6 +22,7 @@ from Products.CMFCore.permissions import AccessInactivePortalContent
 from Products.CMFCore.utils import _checkPermission
 from Products.CMFPlone.CatalogTool import CatalogTool
 from zope.component import getMultiAdapter
+from zope.event import notify
 from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.interface.interfaces import ComponentLookupError
@@ -336,13 +338,14 @@ class ElasticSearchManager:
         hosts, params = utils.get_connection_settings()
 
         if item[1]:
-            update_file_data.delay(
+            job = update_file_data.delay(
                 hosts,
                 params,
                 index_name=self.index_name,
                 body=item,
                 plone_url=self.get_plone_url(),
             )
+            notify(BlobIndexJobCreated(uid=item[0], job=job))
             logger.info("redis task to index blob data created")
 
     def flush_indices(self):

--- a/src/collective/elasticsearch/queueprocessor.py
+++ b/src/collective/elasticsearch/queueprocessor.py
@@ -8,7 +8,7 @@ from collective.elasticsearch.interfaces import IReindexActive
 from collective.elasticsearch.manager import ElasticSearchManager
 from collective.elasticsearch.utils import getESOnlyIndexes
 from collective.elasticsearch.utils import use_redis
-from pkg_resources import parse_version
+from packaging.version import Version as parse_version
 from plone import api
 from plone.app.uuid.utils import uuidToCatalogBrain
 from plone.dexterity.utils import iterSchemata

--- a/src/collective/elasticsearch/queueprocessor.py
+++ b/src/collective/elasticsearch/queueprocessor.py
@@ -8,7 +8,6 @@ from collective.elasticsearch.interfaces import IReindexActive
 from collective.elasticsearch.manager import ElasticSearchManager
 from collective.elasticsearch.utils import getESOnlyIndexes
 from collective.elasticsearch.utils import use_redis
-from packaging.version import Version as parse_version
 from plone import api
 from plone.app.uuid.utils import uuidToCatalogBrain
 from plone.dexterity.utils import iterSchemata
@@ -25,7 +24,7 @@ from zope.schema import getFields
 import transaction
 
 
-if parse_version(api.env.plone_version()) < parse_version("6"):
+if int(api.env.plone_version().split(".")[0]) < 6:
 
     def uuidToObject(uuid, unrestricted=False):
         """Variation of this method, which support the parameter

--- a/src/collective/elasticsearch/tests/test_redis.py
+++ b/src/collective/elasticsearch/tests/test_redis.py
@@ -92,6 +92,10 @@ class TestPloneBackendHost(BaseRedisTest):
         os.environ[
             "PLONE_BACKEND_HOST"
         ] = f'http://{self.layer["host"]}:{self.layer["port"]}'
+        self._transforms = api.portal.get_tool("portal_transforms")
+        for transform_name in list(self._transforms.objectIds()):
+            if "pdf" in transform_name.lower():
+                self._transforms.unregisterTransform(transform_name)
 
     def tearDown(self):
         super().tearDown()
@@ -307,9 +311,18 @@ class TestIndexBlobs(BaseRedisTest):
         self._set_model_file(fti, "plone.app.contenttypes.schema:file.xml")
 
     def test_dont_queue_blob_extraction_jobs_if_not_possible(self):
+        conn = self.es.connection
         settings = {"index": {"default_pipeline": None}}
-        indices_put_settings(self.es.connection, self.es.index_name, settings)
-        self.es.connection.ingest.delete_pipeline(id="cbor-attachments")
+        all_indices = conn.indices.get_settings(index="*")
+        for idx_name, idx_settings in all_indices.items():
+            dp = (
+                idx_settings.get("settings", {})
+                .get("index", {})
+                .get("default_pipeline")
+            )
+            if dp == "cbor-attachments":
+                indices_put_settings(conn, idx_name, settings)
+        conn.ingest.delete_pipeline(id="cbor-attachments")
         file_path = os.path.join(os.path.dirname(__file__), "assets/test2.docx")
         with io.FileIO(file_path, "rb") as pdf:
             self._file = api.content.create(

--- a/src/collective/elasticsearch/utils.py
+++ b/src/collective/elasticsearch/utils.py
@@ -9,16 +9,16 @@ from Products.ZCatalog.CatalogBrains import AbstractCatalogBrain
 from typing import List
 from zope.component import getUtility
 
+import importlib.metadata
 import math
 import os
-import pkg_resources
 
 
 HAS_REDIS_MODULE = False
 try:
-    pkg_resources.get_distribution("redis")
+    importlib.metadata.distribution("redis")
     HAS_REDIS_MODULE = True
-except pkg_resources.DistributionNotFound:
+except importlib.metadata.PackageNotFoundError:
     HAS_REDIS_MODULE = False
 
 


### PR DESCRIPTION
Allows downstream packages to chain dependent jobs (e.g. RAG embedding) that need the extracted text, using RQ's depends_on mechanism.

Also add Plone 6.2 support by removing pkg_resources dependency.