### PR TITLE
Fix scan helper for ES 8 in elastic-synchronize view

### DIFF
--- a/src/collective/elasticsearch/browser/utilviews.py
+++ b/src/collective/elasticsearch/browser/utilviews.py
@@ -1,6 +1,5 @@
 from AccessControl import Unauthorized
 from Acquisition import aq_parent
-from collective.elasticsearch.compat import scan_search
 from collective.elasticsearch.manager import ElasticSearchManager
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch.helpers import scan
@@ -96,10 +95,10 @@ class Utils(BrowserView):
 
     @property
     def _uids_elasticsearch(self):
-        query = {"query": {"match_all": {}}, "_source": ["UID"]}
-        scan_kwargs = scan_search(self._es_conn, self._es.index_name, query)
         items = scan(
-            **scan_kwargs,
+            client=self._es_conn,
+            index=self._es.index_name,
+            query={"query": {"match_all": {}}, "_source": ["UID"]},
             preserve_order=True,
             size=10000,
         )

--- a/src/collective/elasticsearch/compat.py
+++ b/src/collective/elasticsearch/compat.py
@@ -242,32 +242,3 @@ def has_attachment_processor(conn):
             return False
     else:
         return "attachment" in conn.cat.plugins()
-
-
-def scan_search(conn, index, query):
-    """
-    Prepare scan/scroll search parameters compatible with both ES 7 and ES 8.
-
-    In ES 8, the scan helper no longer accepts a full body with 'query' key,
-    instead it expects the query directly.
-
-    Args:
-        conn: Elasticsearch client connection.
-        index: Index name to search.
-        query: Query dictionary (full body with 'query' and '_source' keys).
-
-    Returns:
-        Dictionary of kwargs to pass to elasticsearch.helpers.scan()
-    """
-    if IS_ES_8:
-        return {
-            "client": conn,
-            "index": index,
-            "query": query.get("query"),
-            "_source": query.get("_source"),
-        }
-    return {
-        "client": conn,
-        "index": index,
-        "query": query,
-    }


### PR DESCRIPTION
The ES 8 branch in scan_search passed only the inner query clause to helpers.scan, which expects the full body — causing a 400 "Unknown key for a START_OBJECT in [match_all]". helpers.scan accepts the full body in both ES 7 and ES 8, so drop the now-trivial wrapper and inline scan() at its only call site.