### PR TITLE
Set max_analyzed_offset on SearchableText highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 6.0.0 (unreleased)
 
+- Set `max_analyzed_offset` on the SearchableText highlight field to avoid `search_phase_execution_exception` on documents whose SearchableText exceeds the cluster's `index.highlight.max_analyzed_offset` (ES default: 1,000,000) @maethu
+
 - Run tests against Plone 6.2 @maethu
 
 - Fire BlobIndexJobCreated event after blob extraction job is enqueued, allowing downstream packages to chain dependent jobs via RQ's depends_on @maethu

--- a/src/collective/elasticsearch/manager.py
+++ b/src/collective/elasticsearch/manager.py
@@ -397,7 +397,12 @@ class ElasticSearchManager:
         warnings.simplefilter("ignore", ResourceWarning)
         if self.highlight:
             body["highlight"] = {
-                "fields": {"SearchableText": {"number_of_fragments": 5}},
+                "fields": {
+                    "SearchableText": {
+                        "number_of_fragments": 5,
+                        "max_analyzed_offset": 999999,
+                    }
+                },
                 "pre_tags": self.highlight_pre_tags.split("\n"),
                 "post_tags": self.highlight_post_tags.split("\n"),
             }

--- a/src/collective/elasticsearch/tests/test_search.py
+++ b/src/collective/elasticsearch/tests/test_search.py
@@ -1,3 +1,4 @@
+from collective.elasticsearch.compat import IS_ES_8
 from collective.elasticsearch.testing import ElasticSearch_FUNCTIONAL_TESTING
 from collective.elasticsearch.testing import ElasticSearch_REDIS_TESTING
 from collective.elasticsearch.tests import BaseFunctionalTest
@@ -7,6 +8,7 @@ from DateTime import DateTime
 from parameterized import parameterized
 from parameterized import parameterized_class
 from plone import api
+from plone.app.textfield.value import RichTextValue
 from Products.ZCatalog.interfaces import ICatalogBrain
 
 
@@ -181,6 +183,35 @@ class TestSearch(BaseFunctionalTest):
         results = self.search(query)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].Description, "page <em>Some</em> Page")
+
+    def test_highlight_respects_max_analyzed_offset(self):
+        if not IS_ES_8:
+            self.skipTest("Only run on Elasticsearch 8")
+
+        settings = get_settings()
+        settings.highlight = True
+        settings.highlight_pre_tags = "<em>"
+        settings.highlight_post_tags = "</em>"
+        lorem = (
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
+            "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
+        )
+        long_text = lorem * 15000
+        self.assertGreater(len(long_text), 1000000)
+        api.content.create(
+            self.portal,
+            "Document",
+            "long-page",
+            title="Long",
+            text=RichTextValue(long_text, "text/plain", "text/html"),
+        )
+        self.commit(wait=1)
+        results = self.search({"SearchableText": "lorem"})
+        self.assertEqual(
+            len(results),
+            1,
+            "Search must succeed even when SearchableText exceeds the cluster's highlight.max_analyzed_offset",
+        )
 
     def test_not_query(self):
         api.content.create(self.portal, "Document", "page", title="New Content")


### PR DESCRIPTION
ES rejects searches with search_phase_execution_exception when any document's SearchableText exceeds the cluster's
index.highlight.max_analyzed_offset (default 1,000,000). Pass max_analyzed_offset=999999 on the SearchableText highlight field so a single oversized document no longer poisons the whole search.