### PR TITLE
Skip Redis enqueue on aborted transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 6.0.0 (unreleased)
 
+- Skip Redis enqueue when the ZODB transaction was aborted (e.g. ConflictError). The after-commit hook now respects the transaction outcome, preventing stale data from being shipped to Elasticsearch after a retried/aborted transaction @maethu
+
 - Set `max_analyzed_offset` on the SearchableText highlight field to avoid `search_phase_execution_exception` on documents whose SearchableText exceeds the cluster's `index.highlight.max_analyzed_offset` (ES default: 1,000,000) @maethu
 
 - Run tests against Plone 6.2 @maethu

--- a/src/collective/elasticsearch/queueprocessor.py
+++ b/src/collective/elasticsearch/queueprocessor.py
@@ -195,9 +195,19 @@ class IndexProcessor:
 
         transaction.get().addAfterCommitHook(self._commit_hook_redis)
 
-    def _commit_hook_redis(self, wait=None):
+    def _commit_hook_redis(self, status, wait=None):
         """The after commit hook from redis, includes updateing blobs as
-        well."""
+        well.
+
+        ``addAfterCommitHook`` always passes the transaction outcome
+        (``True`` committed, ``False`` aborted) as the first argument. Skip
+        enqueueing when the transaction was aborted (e.g. ConflictError):
+        Redis is not transactional with ZODB, so a job enqueued from a
+        failed transaction would ship stale data to Elasticsearch.
+        """
+        if not status:
+            self._clean_up()
+            return
         actions = self.actions
         items = len(actions) if actions else 0
         if self.manager.active and items:


### PR DESCRIPTION
addAfterCommitHook always passes the transaction outcome as the first argument; the previous signature silently bound it to `wait`, so the hook ran on aborted commits and shipped stale data to Elasticsearch on ConflictError retries.